### PR TITLE
Add gzip Content-Encoding capability

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -3,7 +3,8 @@ var querystring= require('querystring'),
     https= require('https'),
     http= require('http'),
     URL= require('url'),
-    OAuthUtils= require('./_utils');
+    OAuthUtils= require('./_utils'),
+    zlib= require('zlib');
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._clientId= clientId;
@@ -41,7 +42,6 @@ exports.OAuth2.prototype.setAuthMethod = function ( authMethod ) {
   this._authMethod = authMethod;
 };
 
-
 // If you use the OAuth2 exposed 'get' method (and don't construct your own _request call )
 // this will specify whether to use an 'Authorize' header instead of passing the access_token as a query parameter
 exports.OAuth2.prototype.useAuthorizationHeaderforGET = function(useIt) {
@@ -75,7 +75,6 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   }
 
   var http_library= this._chooseHttpLibrary( parsedUrl );
-
 
   var realHeaders= {};
   for( var key in this._customHeaders ) {
@@ -145,16 +144,23 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 
   var request = http_library.request(options);
   request.on('response', function (response) {
-    response.on("data", function (chunk) {
+    let responseHandler = response
+
+    if (response.headers['content-encoding'] === 'gzip') {
+      responseHandler = zlib.createGunzip();
+      response.pipe(responseHandler);
+    }
+
+    responseHandler.on("data", function (chunk) {
       result+= chunk
     });
-    response.on("close", function (err) {
+    responseHandler.on("close", function (err) {
       if( allowEarlyClose ) {
-        passBackControl( response, result );
+        passBackControl( responseHandler, result );
       }
     });
-    response.addListener("end", function () {
-      passBackControl( response, result );
+    responseHandler.addListener("end", function () {
+      passBackControl( responseHandler, result );
     });
   });
   request.on('error', function(e) {
@@ -185,7 +191,6 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var post_headers= {
        'Content-Type': 'application/x-www-form-urlencoded'
    };
-
 
   this._request("POST", this._getAccessTokenUrl(), post_headers, post_data, null, function(error, data, response) {
     if( error )  callback(error);

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -144,7 +144,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 
   var request = http_library.request(options);
   request.on('response', function (response) {
-    let responseHandler = response
+    var responseHandler = response;
 
     if (response.headers['content-encoding'] === 'gzip') {
       responseHandler = zlib.createGunzip();

--- a/package.json
+++ b/package.json
@@ -1,15 +1,24 @@
-{ "name" : "oauth"
-, "description" : "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers."
-, "version" : "0.9.15"
-, "directories" : { "lib" : "./lib" }
-, "main" : "index.js"
-, "author" : "Ciaran Jessup <ciaranj@gmail.com>"
-, "repository" : { "type":"git", "url":"http://github.com/ciaranj/node-oauth.git" }
-, "devDependencies": {
-    "vows": "0.5.x"
-  }
-, "scripts": {
-    "test": "make test"
-  }
-, "license": "MIT" 
+{
+    "name": "oauth",
+    "description": "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers.",
+    "version": "0.9.15",
+    "directories": {
+        "lib": "./lib"
+    },
+    "main": "index.js",
+    "author": "Ciaran Jessup <ciaranj@gmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "http://github.com/ciaranj/node-oauth.git"
+    },
+    "devDependencies": {
+        "vows": "0.5.x"
+    },
+    "scripts": {
+        "test": "make test"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "zlib": "^1.0.5"
+    }
 }


### PR DESCRIPTION
Some APIs may require that requests/responses are compressed, like Twitter APIv1.1:

https://developer.twitter.com/en/docs/twitter-api/v1/metrics/get-tweet-engagement/api-reference/post-insights-engagement#Totals